### PR TITLE
Implement join and leave mission buttons

### DIFF
--- a/src/pages/Missions/JoinButton.js
+++ b/src/pages/Missions/JoinButton.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+import { joinMission } from '../../redux/missions/missions';
+
+const JoinButton = (props) => {
+  const { id } = props;
+  const dispatch = useDispatch();
+  const handleClick = (e) => {
+    e.stopPropagation();
+    dispatch(joinMission(id));
+  };
+  return (<button type="button" onClick={(e) => handleClick(e)}> Join Mission</button>);
+};
+
+JoinButton.propTypes = {
+  id: PropTypes.string.isRequired,
+};
+
+export default JoinButton;

--- a/src/pages/Missions/LeaveMission.js
+++ b/src/pages/Missions/LeaveMission.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+import { leaveMission } from '../../redux/missions/missions';
+
+const LeaveButton = (props) => {
+  const { id } = props;
+  const dispatch = useDispatch();
+  const handleClick = (e) => {
+    e.stopPropagation();
+    dispatch(leaveMission(id));
+  };
+  return (<button type="button" onClick={(e) => handleClick(e)}> Leave Mission</button>);
+};
+
+LeaveButton.propTypes = {
+  id: PropTypes.string.isRequired,
+};
+
+export default LeaveButton;

--- a/src/pages/Missions/Missions.js
+++ b/src/pages/Missions/Missions.js
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { getMissions } from '../../redux/missions/missions';
+import JoinButton from './JoinButton';
+import LeaveButton from './LeaveMission';
 
 const Missions = () => {
   const dispatch = useDispatch();
@@ -31,13 +33,13 @@ const Missions = () => {
               {mission.member && (
                 <td>
                   {' '}
-                  <button type="button"> Leave Mission</button>
+                  <LeaveButton id={mission.id} />
                 </td>
               )}
               {!mission.member && (
                 <td>
                   {' '}
-                  <button type="button"> Join Mission</button>
+                  <JoinButton id={mission.id} />
                   {' '}
                 </td>
               )}

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,6 +1,8 @@
 const GET_MISSIONS_REQUEST = 'GET_MISSIONS_REQUEST';
 const GET_MISSIONS_SUCCESS = 'GET_MISSIONS_SUCCESS';
 const GET_MISSIONS_FAILED = 'GET_MISSIONS_FAILED';
+const JOIN_MISSION = 'JOIN_MISSION';
+const LEAVE_MISSION = 'LEAVE_MISSION';
 
 export const getMissions = () => (dispatch) => {
   dispatch({ type: GET_MISSIONS_REQUEST });
@@ -26,6 +28,16 @@ export const getMissions = () => (dispatch) => {
   fetchMissions();
 };
 
+export const joinMission = (missionId) => ({
+  type: JOIN_MISSION,
+  payload: missionId,
+});
+
+export const leaveMission = (missionId) => ({
+  type: LEAVE_MISSION,
+  payload: missionId,
+});
+
 const initialState = {
   loading: true,
   missions: [],
@@ -40,6 +52,26 @@ const missionsReducer = (state = initialState, action) => {
       return { ...state, loading: false, missions: action.payload };
     case GET_MISSIONS_FAILED:
       return { ...state, loading: false, error: action.payload };
+    case JOIN_MISSION:
+      return {
+        ...state,
+        missions: state.missions.map(
+          (mission) => ({
+            ...mission,
+            member: (mission.id === action.payload) ? true : mission.member,
+          }),
+        ),
+      };
+    case LEAVE_MISSION:
+      return {
+        ...state,
+        missions: state.missions.map(
+          (mission) => ({
+            ...mission,
+            member: (mission.id === action.payload) ? false : mission.member,
+          }),
+        ),
+      };
     default:
       return state;
   }


### PR DESCRIPTION
This PR bu @JuliCarracedo introduces two new React components to the missions folder
- [x] JoinButton: It includes the required handlers to send a JOIN_MISSION action to the reducer and join the mission
- [x] LeaveButton: It includes the required handlers to send a LEAVE_MISSION action to the reducer and leave the mission
- [x] All the required reducer architecture to update an individual mission and make the **member** property either true or false